### PR TITLE
fix: doubtless bay capture area description LI-6017

### DIFF
--- a/stac/northland/doubtless-bay-and-mangonui-harbour_2025/dem_1m/2193/collection.json
+++ b/stac/northland/doubtless-bay-and-mangonui-harbour_2025/dem_1m/2193/collection.json
@@ -99,7 +99,7 @@
     "capture_area": {
       "href": "./capture-area.geojson",
       "title": "Capture area",
-      "description": "Boundary of the total capture area for this collection. Excludes nodata areas in the source data. Geometries are simplified.",
+      "description": "Boundary of the total capture area for this collection provided by the data supplier. May include some areas of nodata where capture was attempted but unsuccessful. Geometries are simplified.",
       "type": "application/geo+json",
       "roles": ["metadata"],
       "file:checksum": "1220e7eba5ad9eb8f959f295cdd03a4a9f7b7c9ab1663c15a208f7b6cf52de9be82f",


### PR DESCRIPTION
### Motivation & Modification

Update the capture area description in the collection.json to show it was an externally supplied capture area.
