### PR TITLE
fix: missing coastal DEM hillshade parameter file

### DIFF
--- a/publish-odr-parameters/01JXXGZ4206K41PVE53ZVNG4A8-1776904497002.yaml
+++ b/publish-odr-parameters/01JXXGZ4206K41PVE53ZVNG4A8-1776904497002.yaml
@@ -1,0 +1,8 @@
+{
+  "source": "s3://linz-workflows-scratch/2026-04/23-cron-national-merged-dem-hillshades-coastal-1776904200/dem-hillshade-igor/flat/",
+  "target": "s3://nz-coastal/new-zealand/new-zealand/dem-hillshade-igor/2193/",
+  "ticket": "TDE-1479",
+  "copy_option": "--force-no-clobber",
+  "region": "new-zealand",
+  "flatten": "false"
+}


### PR DESCRIPTION
### Motivation & Modifications

Due to merge queue restrictions, this dataset did not get copied and the parameter file did not get merged to master.

Adding the parameter file back in to trigger file copy and STAC sync.